### PR TITLE
Follow the XDG standard for storing APK_SH_HOME dir

### DIFF
--- a/apk.sh
+++ b/apk.sh
@@ -12,7 +12,8 @@
 VERSION="0.9.9"
 echo -e "[*] \033[1mapk.sh v$VERSION \033[0m"
 
-APK_SH_HOME="${HOME}/.apk.sh"
+# Use $XDG_DATA_HOME if set, $HOME if not set
+APK_SH_HOME="${XDG_DATA_HOME-$HOME}/.apk.sh"
 mkdir -p $APK_SH_HOME
 echo "[*] home dir is $APK_SH_HOME"
 


### PR DESCRIPTION
It is a bad practice in GNU/Linux to keep some dot files in the home directory.

There is an [XDG standard](https://specifications.freedesktop.org/basedir-spec/latest/ar01s02.html) that says that the directory to store user data files is defined by `$XDG_DATA_HOME` variable.

After this refinement, the order for selecting the data directory is as follows:
1. `$XDG_DATA_HOME/.apk.sh` (almost always `~/.local/share/.apk.sh`)
2. `~/.apk.sh` (if `$XDG_DATA_HOME` is not set)