### PR TITLE
Add support for adb.exe in WSL2

### DIFF
--- a/apk.sh
+++ b/apk.sh
@@ -431,7 +431,7 @@ apk_pull(){
 	fi
 	PACKAGE=$1
 	BUILD_OPTS=$2
-	PACKAGE_PATH=`adb shell pm path "$PACKAGE" | cut -d ":" -f 2`
+	PACKAGE_PATH=`adb shell pm path "$PACKAGE" | sed 's/\r//' | cut -d ":" -f 2`
 
 	if [ -z "$PACKAGE_PATH" ]; then
 		echo "[>] Sorry, cant find package $PACKAGE"


### PR DESCRIPTION
Since USB support is [not featured out of the box ](https://learn.microsoft.com/en-us/windows/wsl/connect-usb) in [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install), a possible workaround is to [run the adb.exe windows executable from WSL2](https://stackoverflow.com/a/71414575). However, adb.exe will output Windows-style line endings (CR/LF), which are not handled by the shell script. I added a little sed substitution to get rid of CR without side-effects on Linux.

Feel free to reject the PR if it's too specific to WSL2.