### PR TITLE
fix grep error under macOS

### DIFF
--- a/apk.sh
+++ b/apk.sh
@@ -53,7 +53,7 @@ print_(){
 }
 print_ "[*] DEBUG is TRUE"
 
-APKTOOL_VER=`wget https://api.github.com/repos/iBotPeaches/Apktool/releases/latest -q -O - | grep -Po "tag_name\": \"v\K.*?(?=\")"`
+APKTOOL_VER=`wget https://api.github.com/repos/iBotPeaches/Apktool/releases/latest -q -O - | sed -nE 's/.*"tag_name": "v([^"]+)".*/\1/p'`
 APKTOOL_PATH="$APK_SH_HOME/apktool_$APKTOOL_VER.jar"
 
 BUILDTOOLS_VER="33.0.1"


### PR DESCRIPTION
There is an error when trying to retrieve the version number of apktool on macOS because the grep command does not have the `-P` parameter.
Using sed to handle the issue seems to work fine.
<img width="1029" alt="image" src="https://github.com/ax/apk.sh/assets/45651912/50f24737-45cc-467c-b738-8e54c926b044">
It can be executed normally on Ubuntu as well.